### PR TITLE
Add `use_lxd` option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,23 @@ jobs:
           snapcraft_token: ${{ secrets.snapcraft_token }}
       - name: User should be logged in
         run: snapcraft whoami
+
+  # Install with lxd
+  lxd:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v1
+      - name: Run action
+        uses: ./
+      - name: lxd should not be available
+        run: "! /snap/bin/lxd waitready"
+      - name: Run action requesting lxd
+        uses: ./
+        with:
+          use_lxd: true
+      - name: lxd should be installed
+        run: "/snap/bin/lxd waitready"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,4 +64,4 @@ jobs:
         with:
           use_lxd: true
       - name: lxd should be installed
-        run: "/snap/bin/lxd waitready"
+        run: "/snap/bin/lxd version"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v1
@@ -65,6 +65,22 @@ Finally, add the following option to your workflow step:
     snapcraft_token: ${{ secrets.snapcraft_token }}
     skip_install: true # optional, if already installed in an earlier step
 ```
+
+### Build using LXD
+
+LXD (`runs-on: ubuntu-latest`) is for now likely the easiest way to get `snapcraft` to build snaps.
+This is an alternative to using `multipass` (GitHub VMs give the error `launch failed: CPU does not support KVM extensions.` when trying to use `multipass`).
+It takes between 1 to ~10 minutes to set up `lxd` (varies wildly between runs).
+
+```yml
+- name: Install Snapcraft with LXD
+  uses: samuelmeuli/action-snapcraft@v1
+  with:
+    use_lxd: true
+- name: Build snap
+  run: snapcraft --use-lxd
+```
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,7 @@ Finally, add the following option to your workflow step:
 
 ### Build using LXD
 
-LXD (`runs-on: ubuntu-latest`) is for now likely the easiest way to get `snapcraft` to build snaps.
-This is an alternative to using `multipass` (GitHub VMs give the error `launch failed: CPU does not support KVM extensions.` when trying to use `multipass`).
-It takes between 1 to ~10 minutes to set up `lxd` (varies wildly between runs).
+LXD (`runs-on: ubuntu-latest`) is for now likely the easiest way to get `snapcraft` to build snaps. This is an alternative to using `multipass` (GitHub VMs give the error `launch failed: CPU does not support KVM extensions.` when trying to use `multipass`). It takes between 1 to ~10 minutes to set up `lxd` (varies wildly between runs).
 
 ```yml
 - name: Install Snapcraft with LXD
@@ -80,7 +78,6 @@ It takes between 1 to ~10 minutes to set up `lxd` (varies wildly between runs).
 - name: Build snap
   run: snapcraft --use-lxd
 ```
-
 
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
   skip_install:
     description: Skip installation (login only)
     required: false
+  use_lxd:
+    description: Whether to install and configure lxd
+    required: false
 
 runs:
   using: node12

--- a/index.js
+++ b/index.js
@@ -31,13 +31,13 @@ const getPlatform = () => {
  * Installs Snapcraft on Linux
  */
 const runLinuxInstaller = () => {
-	const use_lxd = process.env.INPUT_USE_LXD;
+	const lxd = process.env.INPUT_USE_LXD;
 	run("sudo snap install snapcraft --classic");
-	if (use_lxd) {
+	if (lxd) {
 		run("sudo snap install lxd");
 	}
 	run("sudo chown root:root /"); // Fix root ownership
-	if (use_lxd) {
+	if (lxd) {
 		run("sudo /snap/bin/lxd.migrate -yes");
 		run("sudo /snap/bin/lxd waitready");
 		run("sudo /snap/bin/lxd init --auto");

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const getPlatform = () => {
  * Installs Snapcraft on Linux
  */
 const runLinuxInstaller = () => {
-	const lxd = process.env.INPUT_USE_LXD;
+	const lxd = process.env.INPUT_USE_LXD === "true";
 	run("sudo snap install snapcraft --classic");
 	if (lxd) {
 		run("sudo snap install lxd");

--- a/index.js
+++ b/index.js
@@ -31,8 +31,17 @@ const getPlatform = () => {
  * Installs Snapcraft on Linux
  */
 const runLinuxInstaller = () => {
+	const use_lxd = process.env.INPUT_USE_LXD;
 	run("sudo snap install snapcraft --classic");
+	if (use_lxd) {
+		run("sudo snap install lxd");
+	}
 	run("sudo chown root:root /"); // Fix root ownership
+	if (use_lxd) {
+		run("sudo /snap/bin/lxd.migrate -yes");
+		run("sudo /snap/bin/lxd waitready");
+		run("sudo /snap/bin/lxd init --auto");
+	}
 };
 
 /**


### PR DESCRIPTION
Gives this action the ability to install and set up `lxd` (otherwise `snapcraft` doesn't seem to be able to build anything).

- [x] Document that `multipass` is not supported in GitHub's VMs
- [x] Get the action to install `lxd` (based on optional `with: use_lxd: true` since it may add ~10 min to build time)
- [x] test `use_lxd`
- fixes #2