### PR TITLE
Add `skip_install` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Finally, add the following option to your workflow step:
   uses: samuelmeuli/action-snapcraft@v1
   with:
     snapcraft_token: ${{ secrets.snapcraft_token }}
-    skip_install: true  # optional, if already installed in an earlier step
+    skip_install: true # optional, if already installed in an earlier step
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Finally, add the following option to your workflow step:
   uses: samuelmeuli/action-snapcraft@v1
   with:
     snapcraft_token: ${{ secrets.snapcraft_token }}
+    skip_install: true  # optional, if already installed in an earlier step
 ```
 
 ## Development

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,9 @@ inputs:
   snapcraft_token:
     description: Token for logging into Snapcraft
     required: true
+  skip_install:
+    description: Skip installation (login only)
+    required: false
 
 runs:
   using: node12

--- a/index.js
+++ b/index.js
@@ -31,6 +31,10 @@ const getPlatform = () => {
  * Installs Snapcraft on Linux
  */
 const runLinuxInstaller = () => {
+	if (process.env.INPUT_SKIP_INSTALL) {
+		log("Skipping install");
+		return;
+	}
 	run("sudo snap install snapcraft --classic");
 	run("sudo chown root:root /"); // Fix root ownership
 };
@@ -39,6 +43,10 @@ const runLinuxInstaller = () => {
  * Installs Snapcraft on macOS
  */
 const runMacInstaller = () => {
+	if (process.env.INPUT_SKIP_INSTALL) {
+		log("Skipping install");
+		return;
+	}
 	run("brew install snapcraft");
 };
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ const runAction = () => {
 	if (platform === "windows") {
 		log("Snapcraft is not yet available for Windows. Skipping");
 		process.exit(0);
-	} else if (process.env.INPUT_SKIP_INSTALL) {
+	} else if (process.env.INPUT_SKIP_INSTALL === "true") {
 		log("Skipping install");
 	} else if (platform === "linux") {
 		runLinuxInstaller();

--- a/index.js
+++ b/index.js
@@ -31,10 +31,6 @@ const getPlatform = () => {
  * Installs Snapcraft on Linux
  */
 const runLinuxInstaller = () => {
-	if (process.env.INPUT_SKIP_INSTALL) {
-		log("Skipping install");
-		return;
-	}
 	run("sudo snap install snapcraft --classic");
 	run("sudo chown root:root /"); // Fix root ownership
 };
@@ -43,10 +39,6 @@ const runLinuxInstaller = () => {
  * Installs Snapcraft on macOS
  */
 const runMacInstaller = () => {
-	if (process.env.INPUT_SKIP_INSTALL) {
-		log("Skipping install");
-		return;
-	}
 	run("brew install snapcraft");
 };
 
@@ -58,13 +50,18 @@ const runAction = () => {
 
 	// Install Snapcraft
 	log(`Installing Snapcraft for ${platform.charAt(0).toUpperCase() + platform.slice(1)}…`);
-	if (platform === "linux") {
+	if (platform === "windows") {
+		log("Snapcraft is not yet available for Windows. Skipping");
+		process.exit(0);
+	} else if (process.env.INPUT_SKIP_INSTALL) {
+		log("Skipping install");
+	} else if (platform === "linux") {
 		runLinuxInstaller();
 	} else if (platform === "mac") {
 		runMacInstaller();
 	} else {
-		log("Snapcraft is not yet available for Windows. Skipping");
-		process.exit(0);
+		log("Unknown platform");
+		process.exit(1);
 	}
 
 	// Log in


### PR DESCRIPTION
Allows for neater separation of `install` and `login`, e.g.:

- can install, build, and only then login
- PRs can install & build but `skip_login`
