### PR TITLE
fix snap --use-lxd no longer works with sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ LXD (`runs-on: ubuntu-latest`) is for now likely the easiest way to get `snapcra
   with:
     use_lxd: true
 - name: Build snap
-  run: sudo snapcraft --use-lxd # sudo is required for --use-lxd
+  run: sg lxd -c 'snapcraft --use-lxd'
 ```
 
 ## Development

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ const runLinuxInstaller = () => {
 	run("sudo snap install snapcraft --classic");
 	if (useLxd) {
 		run("sudo snap install lxd");
+		run(`sudo usermod --append --groups lxd ${process.env.USER}`);
 	}
 	run(`echo "::add-path::/snap/bin"`); // Add `/snap/bin` to PATH for subsequent actions
 	run("sudo chown root:root /"); // Fix root ownership


### PR DESCRIPTION
- [x] fix `sudo` no longer supported for `lxd` (use `lxd` user/group instead)
- [x] update documentation
- obsoletes #13
- working proof: [casperdcl:lxd-fix](https://github.com/casperdcl/action-snapcraft) -> https://github.com/casperdcl/cdcl/commit/aa3391800a1a14f61c61b11b68e034d3fc860eb2 -> https://github.com/casperdcl/cdcl/runs/757979236