### PR TITLE
Use ubuntu-18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ on: push
 
 jobs:
   my-job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - name: Check out Git repository
@@ -75,7 +75,7 @@ Finally, add the following option to your workflow step:
 
 ### Build using LXD
 
-LXD (`runs-on: ubuntu-latest`) is for now likely the easiest way to get `snapcraft` to build snaps. This is an alternative to using `multipass` (GitHub VMs give the error `launch failed: CPU does not support KVM extensions.` when trying to use `multipass`).
+LXD (`runs-on: ubuntu-18.04`) is for now likely the easiest way to get `snapcraft` to build snaps. This is an alternative to using `multipass` (GitHub VMs give the error `launch failed: CPU does not support KVM extensions.` when trying to use `multipass`).
 
 ```yml
 - name: Install Snapcraft with LXD


### PR DESCRIPTION
GitHub switched ubuntu-latest to ubuntu-20.04. This action doesn't work with 20.04.

You'll get an error:

```
Installing Snapcraft for Linux…
snapcraft 4.4.4 from Canonical* installed
snap "lxd" is already installed, see 'snap help refresh'
=> Connecting to source server
error: Unable to connect to the source LXD: Get "http://unix.socket/1.0": dial unix /var/lib/lxd/unix.socket: connect: no such file or directory
child_process.js:660
    throw err;
    ^

Error: Command failed: sudo /snap/bin/lxd.migrate -yes
    at checkExecSyncError (child_process.js:621:11)
    at execSync (child_process.js:657:15)
    at run (/home/runner/work/_actions/samuelmeuli/action-snapcraft/v1/index.js:15:2)
    at runLinuxInstaller (/home/runner/work/_actions/samuelmeuli/action-snapcraft/v1/index.js:44:3)
    at runAction (/home/runner/work/_actions/samuelmeuli/action-snapcraft/v1/index.js:71:3)
    at Object.<anonymous> (/home/runner/work/_actions/samuelmeuli/action-snapcraft/v1/index.js:95:1)
    at Module._compile (internal/modules/cjs/loader.js:959:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:995:10)
    at Module.load (internal/modules/cjs/loader.js:815:32)
    at Function.Module._load (internal/modules/cjs/loader.js:727:14) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 1674,
  stdout: null,
  stderr: null
}
```