### PR TITLE
Update action to use node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     deprecationMessage: On ubuntu20.04 or later, it's enabled by default
 
 runs:
-  using: node16
+  using: node20
   main: ./index.js
 
 branding:


### PR DESCRIPTION
This fix the deprecated message:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: samuelmeuli/action-snapcraft@[...].
For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```